### PR TITLE
Fix #2: Create a legacy strategy for Spark Archives Kasper 6 Project

### DIFF
--- a/vertigo-chroma-plugin/META-INF/MANIFEST.MF
+++ b/vertigo-chroma-plugin/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: KspPlugin
 Bundle-SymbolicName: io.vertigo.chroma.kspPlugin;singleton:=true
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1
 Bundle-Activator: io.vertigo.chroma.kspplugin.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/vertigo-chroma-plugin/src/io/vertigo/chroma/kspplugin/legacy/LegacyManager.java
+++ b/vertigo-chroma-plugin/src/io/vertigo/chroma/kspplugin/legacy/LegacyManager.java
@@ -153,6 +153,11 @@ public final class LegacyManager implements Manager, IResourceChangeListener {
 			return LegacyVersion.KASPER_6;
 		}
 
+		/* Kasper 6 - Spark */
+		if (isTypeExists("spark.commons.SparkRuntimeException", project)) {
+			return LegacyVersion.SPARK_KASPER_6;
+		}
+
 		/* Kasper 5 */
 		if (isTypeExists("org.codehaus.janino.ScriptEvaluator", project)) {
 			return LegacyVersion.KASPER_5;

--- a/vertigo-chroma-plugin/src/io/vertigo/chroma/kspplugin/legacy/LegacyVersion.java
+++ b/vertigo-chroma-plugin/src/io/vertigo/chroma/kspplugin/legacy/LegacyVersion.java
@@ -16,6 +16,11 @@ public enum LegacyVersion {
 	KASPER_6(new Kasper6Strategy()),
 
 	/**
+	 * Spark.
+	 */
+	SPARK_KASPER_6(new SparkKasper6Strategy()),
+
+	/**
 	 * Kasper 5.
 	 */
 	KASPER_5(new Kasper5Strategy()),

--- a/vertigo-chroma-plugin/src/io/vertigo/chroma/kspplugin/legacy/SparkKasper6Strategy.java
+++ b/vertigo-chroma-plugin/src/io/vertigo/chroma/kspplugin/legacy/SparkKasper6Strategy.java
@@ -1,0 +1,94 @@
+package io.vertigo.chroma.kspplugin.legacy;
+
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.jdt.core.IType;
+
+import io.vertigo.chroma.kspplugin.model.DtoField;
+import io.vertigo.chroma.kspplugin.model.DtoReferencePattern;
+import io.vertigo.chroma.kspplugin.model.KspAttribute;
+import io.vertigo.chroma.kspplugin.model.KspDeclarationMainParts;
+import io.vertigo.chroma.kspplugin.model.KspDeclarationNameParts;
+import io.vertigo.chroma.kspplugin.model.KspDeclarationParts;
+import io.vertigo.chroma.kspplugin.model.KspNature;
+import io.vertigo.chroma.kspplugin.utils.DtoUtils;
+import io.vertigo.chroma.kspplugin.utils.JdtUtils;
+import io.vertigo.chroma.kspplugin.utils.KspStringUtils;
+import io.vertigo.chroma.kspplugin.utils.ResourceUtils;
+import io.vertigo.chroma.kspplugin.utils.StringUtils;
+
+/**
+ * Strat??gie pour les projets en Kasper 6.
+ */
+public final class SparkKasper6Strategy implements LegacyStrategy {
+
+	@Override
+	public KspDeclarationParts getKspDeclarationParts(String lineContent) {
+		KspDeclarationMainParts mainParts = KspStringUtils.getKasper6KspDeclarationParts(lineContent);
+		if (mainParts == null) {
+			return null;
+		}
+
+		/* Extrait le pr??fixe et le nom simple de la d??claration */
+		KspDeclarationNameParts declarationNameParts = KspStringUtils.getKspDeclarationNameParts(mainParts.getConstantCaseName());
+		if (declarationNameParts == null) {
+			return null;
+		}
+
+		return new KspDeclarationParts(mainParts, declarationNameParts);
+	}
+
+	@Override
+	public String getKspDeclarationJavaName(String constantCaseNameOnly, String nature) {
+		if ("Task".equals(nature)) {
+			return StringUtils.toCamelCase(constantCaseNameOnly);
+		}
+		return StringUtils.toPascalCase(constantCaseNameOnly);
+	}
+
+	@Override
+	public KspAttribute getKspAttribute(String lineContent) {
+		return KspStringUtils.getKasper6KspAttribute(lineContent);
+	}
+
+	@Override
+	public boolean isDtoType(IType type) {
+		return JdtUtils.isVertigoDtoType(type);
+	}
+
+	@Override
+	public boolean isDtoCandidate(IFile file) {
+		/* Pas de convention de nommage sur les DTO. */
+		/* On v??rifie que c'est un fichier Java dans le dossier Javagen. */
+		return ResourceUtils.isSrcSparkGenerated(file) && ResourceUtils.isJavaFile(file);
+	}
+
+	@Override
+	public List<DtoField> parseDtoFields(IType type) {
+		return DtoUtils.parseVertigoDtoFields(type);
+	}
+
+	@Override
+	public boolean isServiceCandidate(IFile file) {
+		/* V??rifie la convention de nommage. */
+		return KspStringUtils.getSparkServiceFileName(file.getName()) != null;
+	}
+
+	@Override
+	public boolean isDaoCandidate(IFile file) {
+		/* V??rifie que le fichier est dans Javagen */
+		/* Filtre avec la convention de nommage sur le nom du fichier. */
+		return ResourceUtils.isSrcSparkGenerated(file) && KspStringUtils.getDaoFileName(file.getName()) != null;
+	}
+
+	@Override
+	public String getKspKeyword(KspNature kspNature) {
+		return kspNature.getKspKeyword();
+	}
+
+	@Override
+	public DtoReferencePattern getDtoReferenceSyntaxe() {
+		return DtoReferencePattern.DOMAIN;
+	}
+}

--- a/vertigo-chroma-plugin/src/io/vertigo/chroma/kspplugin/utils/KspStringUtils.java
+++ b/vertigo-chroma-plugin/src/io/vertigo/chroma/kspplugin/utils/KspStringUtils.java
@@ -36,6 +36,7 @@ public final class KspStringUtils {
 	private static final Pattern KASPER_4_DAO_FILE_NAME = Pattern.compile("^(Services.+)\\.java$");
 	private static final Pattern KASPER_3_DAO_FILE_NAME = Pattern.compile("^(.+Services)\\.java$");
 	private static final Pattern VERTIGO_SERVICE_FILE_NAME = Pattern.compile("^(.+ServicesImpl)\\.java$");
+	private static final Pattern SPARK_SERVICE_FILE_NAME = Pattern.compile("^(.+Service)\\.java$");
 	private static final Pattern KASPER_4_SERVICE_FILE_NAME = Pattern.compile("^(Facade.+Bean)\\.java$");
 	private static final Pattern KASPER_3_SERVICE_FILE_NAME = Pattern.compile("^(.+FacadeMetier)\\.java$");
 	private static final Pattern WS_FILE_NAME = Pattern.compile("^(.*Web.*)\\.java$");
@@ -251,6 +252,14 @@ public final class KspStringUtils {
 
 	public static String getKasper4ServiceFileName(String s) {
 		Matcher matcher = KASPER_4_SERVICE_FILE_NAME.matcher(s);
+		if (matcher.matches()) {
+			return matcher.group(1);
+		}
+		return null;
+	}
+
+	public static String getSparkServiceFileName(String s) {
+		Matcher matcher = SPARK_SERVICE_FILE_NAME.matcher(s);
 		if (matcher.matches()) {
 			return matcher.group(1);
 		}

--- a/vertigo-chroma-plugin/src/io/vertigo/chroma/kspplugin/utils/ResourceUtils.java
+++ b/vertigo-chroma-plugin/src/io/vertigo/chroma/kspplugin/utils/ResourceUtils.java
@@ -101,6 +101,16 @@ public final class ResourceUtils {
 	}
 
 	/**
+	 * Indique si une ressource est dans le dossier de classes générées de Spark.
+	 *
+	 * @param resource Resource.
+	 * @return <code>true</code> si la ressource est dans le dossier target/generated-sources/ksp.
+	 */
+	public static boolean isSrcSparkGenerated(IResource resource) {
+		return resource.getFullPath().toString().contains("target/generated-sources/ksp");
+	}
+
+	/**
 	 * Indique si une ressource est un fichier Java.
 	 * 
 	 * @param resource Resource.


### PR DESCRIPTION
Plugin version upped to 1.0.1.
I had issues installing again the 1.0.0 during local debug.